### PR TITLE
Add support for private keys stored on PKCS11 tokens

### DIFF
--- a/common/lib/tls-reader.js
+++ b/common/lib/tls-reader.js
@@ -33,7 +33,9 @@ var exceptions = require('./exceptions');
 module.exports = function(options) {
 
    // verify certificate paths
-   if (isUndefined(options.keyPath) && isUndefined(options.privateKey)) {
+   if (isUndefined(options.keyPath) &&
+      isUndefined(options.privateKey) &&
+      isUndefined(options.privateKeyPKCSIdentifier)) {
       throw new Error(exceptions.NO_KEY_OPTION);
    }
    if (isUndefined(options.certPath) && isUndefined(options.clientCert)) {
@@ -100,6 +102,15 @@ module.exports = function(options) {
       options.ca = filesys.readFileSync(options.caPath);
    } else if (!isUndefined(options.caPath)) {
       throw new Error(exceptions.INVALID_CA_PATH_OPTION);
+   }
+
+   // If the private key is provided by PKCS11, we don't set key, we set
+   // privateKeyEngine and privateKeyIdentifier.
+   if (options.privateKeyPKCSIdentifier) {
+      options.key = undefined;
+      delete options['key'];
+      options.privateKeyEngine = 'pkcs11';
+      options.privateKeyIdentifier = options.privateKeyPKCSIdentifier;
    }
 
    // request certificate from partner


### PR DESCRIPTION
Everything down the chain, shockingly, has great support for openssl engines, and PKCS11 as a result. But the device SDK was too smart for it's own good and validated too many things about the passed in options.

This PR just allows adding a `privateKeyPKCSIdentifier` to the aws.config, which will access the private key using PKCS11 to get to the TPM.

Small app change needed as well, will open another PR for that. Nothing scary.

(FYI @davidchappelle @jshantz-miovision - this is the (small) change needed to support IoT private keys stored on the TPM, along with a minor change to provisioning, and an OPENSSL_CONF environment variable. )